### PR TITLE
Improve error handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,11 +1,19 @@
 from src import config_loader, db_connection, api_service
 
 def main():
-    config = config_loader.load_yaml_config("config/config.yaml")
-    mongo_cfg = config_loader.load_json_config(config["mongo"]["config_file"])[config["mongo"]["db_id"]]
-    collection = db_connection.get_mongo_client(mongo_cfg)
-    app = api_service.create_app(collection)
-    app.run(host=config["server"]["host"], port=config["server"]["port"])
+    try:
+        config = config_loader.load_yaml_config("config/config.yaml")
+        mongo_cfg = config_loader.load_json_config(
+            config["mongo"]["config_file"]
+        )[config["mongo"]["db_id"]]
+        collection = db_connection.get_mongo_client(mongo_cfg)
+        app = api_service.create_app(collection)
+        app.run(
+            host=config["server"]["host"],
+            port=config["server"]["port"],
+        )
+    except Exception as exc:
+        print(f"Application failed to start: {exc}")
 
 if __name__ == "__main__":
     main()

--- a/mongo_api.py
+++ b/mongo_api.py
@@ -1,26 +1,35 @@
 from flask import Flask, jsonify
-from pymongo import MongoClient
+from pymongo import MongoClient, errors
 from datetime import datetime
 
 app = Flask(__name__)
 #client = MongoClient("mongodb://192.168.1.90:27017")  # Change as needed
-client = MongoClient("mongodb://grafana_user:mi_clave_segura@192.168.132.10:27017/test_db?authSource=test_db")
+try:
+    client = MongoClient(
+        "mongodb://grafana_user:mi_clave_segura@192.168.132.10:27017/test_db?authSource=test_db"
+    )
+except errors.PyMongoError as exc:
+    raise SystemExit(f"Mongo connection failed: {exc}")
 
 db = client["test_db"]
 collection = db["sensor_data"]
 
 @app.route("/api/sensor-data", methods=["GET"])
 def get_sensor_data():
-    cursor = collection.find().sort("timestamp", -1).limit(100)
-    result = []
-    for doc in cursor:
-        result.append({
-            "timestamp": doc.get("timestamp"),
-            "temperature": doc.get("temperature"),
-            "humidity": doc.get("humidity")
-        })
-    return jsonify(result)
+    try:
+        cursor = collection.find().sort("timestamp", -1).limit(100)
+        result = []
+        for doc in cursor:
+            result.append({
+                "timestamp": doc.get("timestamp"),
+                "temperature": doc.get("temperature"),
+                "humidity": doc.get("humidity")
+            })
+        return jsonify(result)
+    except errors.PyMongoError:
+        return jsonify({"error": "Database error"}), 500
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=5000)
+
 

--- a/src/api_service.py
+++ b/src/api_service.py
@@ -1,18 +1,22 @@
 from flask import Flask, jsonify
+from pymongo import errors
 
 def create_app(mongo_collection):
     app = Flask(__name__)
 
     @app.route("/api/sensor-data", methods=["GET"])
     def get_sensor_data():
-        cursor = mongo_collection.find().sort("timestamp", -1).limit(100)
-        result = []
-        for doc in cursor:
-            result.append({
-                "timestamp": doc.get("timestamp"),
-                "temperature": doc.get("temperature"),
-                "humidity": doc.get("humidity")
-            })
-        return jsonify(result)
+        try:
+            cursor = mongo_collection.find().sort("timestamp", -1).limit(100)
+            result = []
+            for doc in cursor:
+                result.append({
+                    "timestamp": doc.get("timestamp"),
+                    "temperature": doc.get("temperature"),
+                    "humidity": doc.get("humidity")
+                })
+            return jsonify(result)
+        except errors.PyMongoError as exc:
+            return jsonify({"error": "Database error"}), 500
 
     return app

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -2,9 +2,17 @@ import yaml
 import json
 
 def load_yaml_config(file_path):
-    with open(file_path, 'r') as f:
-        return yaml.safe_load(f)
+    """Load YAML configuration file."""
+    try:
+        with open(file_path, 'r') as f:
+            return yaml.safe_load(f)
+    except (OSError, yaml.YAMLError) as exc:
+        raise RuntimeError(f"Error loading YAML config: {file_path}") from exc
 
 def load_json_config(file_path):
-    with open(file_path, 'r') as f:
-        return json.load(f)
+    """Load JSON configuration file."""
+    try:
+        with open(file_path, 'r') as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"Error loading JSON config: {file_path}") from exc

--- a/src/db_connection.py
+++ b/src/db_connection.py
@@ -1,7 +1,18 @@
-from pymongo import MongoClient
+from pymongo import MongoClient, errors
 
 ##TODO: Add try, except 
 def get_mongo_client(cfg):
-    uri = f"mongodb://{cfg['user']}:{cfg['password']}@{cfg['host']}:{cfg['port']}/{cfg['db_name']}?authSource={cfg['auth_source']}"
-    client = MongoClient(uri)
-    return client[cfg['db_name']][cfg['collection']]
+    """Return a MongoDB collection based on configuration."""
+    try:
+        uri = (
+            f"mongodb://{cfg['user']}:{cfg['password']}@"
+            f"{cfg['host']}:{cfg['port']}/{cfg['db_name']}?authSource={cfg['auth_source']}"
+        )
+    except KeyError as exc:
+        raise ValueError("Invalid Mongo configuration") from exc
+
+    try:
+        client = MongoClient(uri)
+        return client[cfg['db_name']][cfg['collection']]
+    except errors.PyMongoError as exc:
+        raise ConnectionError("Could not connect to MongoDB") from exc


### PR DESCRIPTION
## Summary
- add error handling to configuration loaders
- ensure MongoDB client creation is resilient
- handle DB errors in the API service
- wrap initialization in `main`
- add try/except to example script

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850290eb2988327a6738fa779bdf5b1